### PR TITLE
fix(meta): add trollius script entry-point

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: c5ace2e0c17651f6d378e5231fcc1b3408717b95b29ef7cc10445253679cb246
 
 build:
-  noarch: python
-  number: 0
+  entry_points:
+    - trollius-to-async = asyncio_helpers.trollius_to_async:main
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -20,8 +21,8 @@ requirements:
     - pip
   run:
     - logging-helpers
-    - python >=2.7,<3.7
-    - trollius
+    - python >=2.7
+    - trollius  # [py<35]
 
 test:
   imports:


### PR DESCRIPTION
 - Add `trollius-to-async` script entry-point. May be used to convert
   Python 2.7/`trollius` Python files to Python 3 `async` syntax.
 - Do not include `trollius` package `run` requirement for Python
   versions where `async` is not available (i.e., Python <3.5).
 - Remove `noarch: python` build flag, since the package has different
   run requirements depending on the Python version. Therefore, the
   package must be built for each Python platform.
 - Bump the `build` number to 1, since no code has changed since the
   previous 0.4.2 build.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
